### PR TITLE
Fix sine synth underflow

### DIFF
--- a/examples/sine_synth.rs
+++ b/examples/sine_synth.rs
@@ -13,10 +13,11 @@ use std::f64::consts::PI;
 ///
 /// This function assumes A4 is 440hz.
 fn midi_pitch_to_freq(pitch: u8) -> f64 {
-    const A4_PITCH: u8 = 69;
+    const A4_PITCH: i8 = 69;
     const A4_FREQ: f64 = 440.0;
 
-    (((pitch - A4_PITCH) as f64) / 12.).exp2() * A4_FREQ
+    // Midi notes can be 0-127
+    (((pitch as i8 - A4_PITCH) as f64) / 12.).exp2() * A4_FREQ
 }
 
 struct SineSynth {
@@ -146,3 +147,16 @@ impl Plugin for SineSynth {
 }
 
 plugin_main!(SineSynth);
+
+#[cfg(test)]
+mod tests {
+    use midi_pitch_to_freq;
+
+    #[test]
+    fn test_midi_pitch_to_freq() {
+        for i in 0..127 {
+            // expect no panics
+            midi_pitch_to_freq(i);
+        }
+    }
+}


### PR DESCRIPTION
Fix proposed in https://github.com/rust-dsp/rust-vst/issues/20
Also added a test for verifying that all valid midi notes don't crash.

Fixes https://github.com/rust-dsp/rust-vst/issues/20