### PR TITLE
Raw host callback access, for accessing host specific functionality, e.g. the Reaper Extension API

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -748,6 +748,7 @@ pub trait Plugin {
 /// # }
 /// # fn main() { let plugin: ExamplePlugin = Default::default(); }
 /// ```
+#[derive(Copy, Clone)]
 pub struct HostCallback {
     callback: Option<HostCallbackProc>,
     effect: *mut AEffect,
@@ -776,9 +777,7 @@ impl HostCallback {
         ptr: *mut c_void,
         opt: f32,
     ) -> isize {
-        let callback = self.callback.unwrap_or_else(
-            || panic!("Host not yet initialized."),
-        );
+        let callback = self.callback.unwrap_or_else(|| panic!("Host not yet initialized."));
         callback(effect, opcode.into(), index, value, ptr, opt)
     }
 
@@ -808,6 +807,18 @@ impl HostCallback {
             ptr::null_mut(),
             0.0,
         ) as i32
+    }
+
+    /// Get the callback for calling host-specific extensions
+    #[inline(always)]
+    pub fn raw_callback(&self) -> Option<HostCallbackProc> {
+        self.callback
+    }
+
+    /// Get the effect pointer for calling host-specific extensions
+    #[inline(always)]
+    pub fn raw_effect(&self) -> *mut AEffect {
+        self.effect
     }
 
     fn read_string(&self, opcode: host::OpCode, max: usize) -> String {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -765,6 +765,8 @@ impl Default for HostCallback {
     }
 }
 
+unsafe impl Send for HostCallback {}
+
 impl HostCallback {
     /// Wrap callback in a function to avoid using fn pointer notation.
     #[doc(hidden)]


### PR DESCRIPTION
I'm using this successfully in my Reaper VST, e.g.:
```rust

#[derive(new)]
pub struct ReaperHost(HostCallback);

impl ReaperHost {
	/// Get a pointer to the Reaper extension function by name (when running in Reaper)
	#[allow(overflowing_literals)]
	fn get_reaper_fn<F>(&self, func: &str) -> Option<F> {
        let callback = self.0.raw_callback().unwrap_or_else(|| panic!("Host not yet initialized."));
		use std::ffi::CString;
		use std::mem::transmute_copy;
		let f = callback(self.0.raw_effect(), 0xdeadbeef, 0xdeadf00d, 0, CString::new(func).unwrap().as_ptr() as _, 0.) as *const ();
		if f.is_null() { None } else { Some(unsafe { transmute_copy(&f) }) }
	}
	pub fn get_api(&self) -> Option<ReaperApi> {
		macro_rules! load {
			(@ $f:tt) => { let $f: $f = self.get_reaper_fn(stringify!(f))?; };
			($($fs:tt,)+) => { load!($($fs),+) };
			($($fs:tt),*) => { { $(load!(@ $fs));+; Some(ReaperApi { $($fs),+ }) } }
		}
		load!(
			GetNumTracks,
			GetTrack,
			GetMasterTrack,
			GetTrackName,
			TrackFX_GetCount,
			TrackFX_GetFXName,
			GetTrackGUID,
			TrackFX_GetFXGUID,
			guidToString,
			TrackFX_GetNumParams,
			TrackFX_GetParamName,
			TrackFX_GetParamNormalized,
			TrackFX_SetParamNormalized,
			SetMediaTrackInfo_Value,
			CSurf_OnVolumeChange,
			CSurf_OnTempoChange,
			GetTrackNumSends,
			GetTrackSendUIVolPan,
			SetTrackSendUIVol,
			TrackFX_SetEnabled,
		)
	}
}

pub struct ReaperApi {
	pub GetNumTracks: GetNumTracks,
	pub GetTrack: GetTrack,
	pub GetMasterTrack: GetMasterTrack,
	pub GetTrackName: GetTrackName,
	pub TrackFX_GetCount: TrackFX_GetCount,
	pub TrackFX_GetFXName: TrackFX_GetFXName,
	pub GetTrackGUID: GetTrackGUID,
	pub TrackFX_GetFXGUID: TrackFX_GetFXGUID,
	pub guidToString: guidToString,
	pub TrackFX_GetNumParams: TrackFX_GetNumParams,
	pub TrackFX_GetParamName: TrackFX_GetParamName,
	pub TrackFX_GetParamNormalized: TrackFX_GetParamNormalized,
	pub TrackFX_SetParamNormalized: TrackFX_SetParamNormalized,
	pub SetMediaTrackInfo_Value: SetMediaTrackInfo_Value,
	pub CSurf_OnVolumeChange: CSurf_OnVolumeChange,
	pub CSurf_OnTempoChange: CSurf_OnTempoChange,

	pub GetTrackNumSends: GetTrackNumSends,
	pub GetTrackSendUIVolPan: GetTrackSendUIVolPan,
	pub SetTrackSendUIVol: SetTrackSendUIVol,
	pub TrackFX_SetEnabled: TrackFX_SetEnabled,
}

pub type c_bool = bool; // true == success
pub enum GUID {}
pub enum ReaProject {}
pub enum MediaTrack {}

// int (*GetNumTracks)();
pub type GetNumTracks = extern fn() -> c_int;

// MediaTrack* GetTrack(ReaProject* proj, int trackidx)
pub type GetTrack = extern fn(proj: *mut ReaProject, trackidx: c_int) -> *mut MediaTrack;

// MediaTrack* GetMasterTrack(ReaProject* proj)
pub type GetMasterTrack = extern fn(proj: *mut ReaProject) -> *mut MediaTrack;

// bool GetTrackName(MediaTrack* track, char* buf, int buf_sz)
pub type GetTrackName = extern fn(track: *mut MediaTrack, buf: *mut c_char, buf_sz: c_int) -> c_bool;

// int TrackFX_GetCount(MediaTrack* track)
pub type TrackFX_GetCount = extern fn(track: *mut MediaTrack) -> c_int;

// bool TrackFX_GetFXName(MediaTrack* track, int fx, char* buf, int buf_sz)
pub type TrackFX_GetFXName = extern fn(track: *mut MediaTrack, fx: c_int, buf: *mut c_char, buf_sz: c_int) -> c_bool;

// GUID* GetTrackGUID(MediaTrack* tr)
pub type GetTrackGUID = extern fn(track: *mut MediaTrack) -> *const GUID;

// GUID* TrackFX_GetFXGUID(MediaTrack* track, int fx)
pub type TrackFX_GetFXGUID = extern fn(track: *mut MediaTrack, fx: c_int) -> *const GUID;

// void guidToString(const GUID* g, char* destNeed64)
pub type guidToString = extern fn(g: *const GUID, destNeed64: *mut c_char);

// int TrackFX_GetNumParams(MediaTrack* track, int fx)
pub type TrackFX_GetNumParams = extern fn(track: *mut MediaTrack, fx: c_int) -> c_int;

// bool TrackFX_GetParamName(MediaTrack* track, int fx, int param, char* buf, int buf_sz)
pub type TrackFX_GetParamName = extern fn(track: *mut MediaTrack, fx: c_int, param: c_int, buf: *mut c_char, buf_sz: c_int) -> c_bool;

// double TrackFX_GetParamNormalized(MediaTrack* track, int fx, int param)
pub type TrackFX_GetParamNormalized = extern fn(track: *mut MediaTrack, fx: c_int, param: c_int) -> c_double;

// bool TrackFX_SetParamNormalized(MediaTrack* track, int fx, int param, double value)
pub type TrackFX_SetParamNormalized = extern fn(track: *mut MediaTrack, fx: c_int, param: c_int, value: c_double) -> c_bool;

// bool SetMediaTrackInfo_Value(MediaTrack* tr, const char* parmname, double newvalue)
pub type SetMediaTrackInfo_Value = extern fn(track: *mut MediaTrack, parmname: *const c_char, newvalue: c_double) -> c_bool;

// double CSurf_OnVolumeChange(MediaTrack* trackid, double volume, bool relative)
pub type CSurf_OnVolumeChange = extern fn(track: *mut MediaTrack, volume: c_double, relative: c_bool) -> c_double;

// void CSurf_OnTempoChange(double bpm)
pub type CSurf_OnTempoChange = extern fn(bpm: c_double);

// int GetTrackNumSends(MediaTrack* tr, int category)
pub type GetTrackNumSends = extern fn(track: *mut MediaTrack, category: c_int) -> c_int;

// bool GetTrackSendUIVolPan(MediaTrack* track, int send_index, double* volumeOut, double* panOut)
pub type GetTrackSendUIVolPan = extern fn(track: *mut MediaTrack, send_index: c_int, volumeOut: *mut c_double, panOut: *mut c_double) -> c_bool;

// bool SetTrackSendUIVol(MediaTrack* track, int send_idx, double vol, int isend)
pub type SetTrackSendUIVol = extern fn(track: *mut MediaTrack, send_index: c_int, vol: c_double, isend: c_int) -> c_double;

// void TrackFX_SetEnabled(MediaTrack* track, int fx, bool enabled)
pub type TrackFX_SetEnabled = extern fn(track: *mut MediaTrack, fx: c_int, enabled: c_bool);



```