### PR TITLE
Improved midi sending: SendEventBuffer::send_events()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,7 @@ crate-type = ["bin"]
 [[example]]
 name = "sine_synth"
 crate-type = ["cdylib"]
+
+[[example]]
+name = "fwd_midi"
+crate-type = ["cdylib"]

--- a/examples/fwd_midi.rs
+++ b/examples/fwd_midi.rs
@@ -1,0 +1,77 @@
+#[macro_use]
+extern crate vst;
+
+use vst::plugin::{Info, Plugin, CanDo, HostCallback};
+use vst::event::{Event, MidiEvent};
+use vst::buffer::{AudioBuffer, SendEventBuffer};
+use vst::api;
+
+plugin_main!(MyPlugin); // Important!
+
+#[derive(Default)]
+struct MyPlugin {
+	host: HostCallback,
+	events: Vec<MidiEvent>,
+	send_buffer: SendEventBuffer,
+}
+
+impl MyPlugin {
+	fn send_midi(&mut self) {
+		self.send_buffer.send_events(&self.events, &mut self.host);
+		self.events.clear();
+	}
+}
+
+impl Plugin for MyPlugin {
+	fn new(host: HostCallback) -> Self {
+		let mut p = MyPlugin::default();
+		p.host = host;
+		p
+	}
+
+	fn get_info(&self) -> Info {
+		Info {
+			name: "fwd_midi".to_string(),
+			unique_id: 7357001, // Used by hosts to differentiate between plugins.
+			..Default::default()
+		}
+	}
+
+	fn process_events(&mut self, events: &api::Events) {
+		for e in events.events() {
+			match e {
+				Event::Midi(e) => self.events.push(e),
+				_ => (),
+			}
+		}
+	}
+
+	fn process(&mut self, buffer: &mut AudioBuffer<f32>) {
+		for (input, output) in buffer.zip() {
+			for (in_sample, out_sample) in input.iter().zip(output) {
+				*out_sample = *in_sample;
+			}
+		}
+		self.send_midi();
+	}
+
+	fn process_f64(&mut self, buffer: &mut AudioBuffer<f64>) {
+		for (input, output) in buffer.zip() {
+			for (in_sample, out_sample) in input.iter().zip(output) {
+				*out_sample = *in_sample;
+			}
+		}
+		self.send_midi();
+	}
+
+	fn can_do(&self, can_do: CanDo) -> vst::api::Supported {
+		use vst::api::Supported::*;
+		use vst::plugin::CanDo::*;
+
+		match can_do {
+			SendEvents | SendMidiEvent | ReceiveEvents | ReceiveMidiEvent => Yes,
+			_ => No,
+		}
+	}
+}
+

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -374,12 +374,10 @@ impl SendEventBuffer {
                 *ptr = event;
             }
         }
-        let mut r = Self {
+        Self {
             buf: buf,
             api_events: api_events,
-        };
-        r.set_num_events(0);
-        r
+        }
     }
 
     /// Sends events to the host. See the `fwd_midi` example.

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -88,7 +88,7 @@ fn copy_string(dst: *mut c_void, src: &str, max: usize) -> isize {
 
         let dst = dst as *mut c_void;
         memset(dst, 0, max);
-        memcpy(dst, src.as_ptr() as *const c_void, min(max, src.len()));
+        memcpy(dst, src.as_ptr() as *const c_void, min(max, src.as_bytes().len()));
     }
 
     1 // Success
@@ -292,7 +292,7 @@ pub fn dispatch(
         }
 
         _ => {
-            warn!("Unimplemented opcode ({:?})", opcode);
+            debug!("Unimplemented opcode ({:?})", opcode);
             trace!(
                 "Arguments; index: {}, value: {}, ptr: {:?}, opt: {}",
                 index,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,8 +91,6 @@
 //! [`PluginLoader::load`]: host/struct.PluginLoader.html#method.load
 //!
 
-#![cfg_attr(feature = "nightly", feature(conservative_impl_trait))]
-
 extern crate libc;
 extern crate num_traits;
 extern crate libloading;


### PR DESCRIPTION
Now it's easier to use and will always send the correct number of events.

Before, it was possible to accidentally call `Host::process_events` before calling `SendEventBuffer::store` (or `store_midi`) which would cause the buffer contents to be sent from the last time that `store` or `store_midi` was called. 
And before, if `Host::process_events` would be called before any call to `store` or `store_midi`, it would have send a full buffer of zeroed out `SysExEvent`s (`num_events` would still have been `capacity` (i.e. 1024 in the default case) from `new()`). 

Now by making `SendEventBuffer::events()` private and only using it in `SendEventBuffer::send_events()` after having called `store_events` which calls `set_num_events` to set the correct number of events, it's now impossible to call `SendEventBuffer::events()` with an incorrect `num_events` value being set.

Also I added the type
```rust
/// This is used as a placeholder to pre-allocate space for a fixed number of midi events in the re-useable `SendEventBuffer`, because `SysExEvent` is larger than `MidiEvent`, so either one can be stored in a `SysExEvent`.
pub type PlaceholderEvent = api::SysExEvent;
```
to make it more clear why we are using `api::SysExEvent` as placeholder in the `SendEventBuffer`, and added a trait `WriteIntoPlaceholder` to generically allow `SendEventBuffer::send_events()` to work on Iterators over `Event`, or just `MidiEvent` (or references of those, or over Iterators of `SysExEvent` but that will be very uncommon).
