### PR TITLE
Make CanDo::from_str infallible

### DIFF
--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -247,13 +247,7 @@ pub fn dispatch(
         OpCode::GetVendorVersion => return plugin.get_info().version as isize,
         OpCode::VendorSpecific => return plugin.vendor_specific(index, value, ptr, opt),
         OpCode::CanDo => {
-            let can_do: CanDo = match read_string(ptr).parse() {
-                Ok(c) => c,
-                Err(e) => {
-                    warn!("{}", e);
-                    return 0;
-                }
-            };
+            let can_do = CanDo::from_str(&read_string(ptr));
             return plugin.can_do(can_do).into();
         }
         OpCode::GetTailSize => {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -395,14 +395,13 @@ pub enum CanDo {
     Other(String),
 }
 
-use std::str::FromStr;
-impl FromStr for CanDo {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<CanDo, String> {
+impl CanDo {
+    /// Converts a string to a `CanDo` instance. Any given string that does not match the predefined
+    /// values will return a `CanDo::Other` value.
+    pub fn from_str(s: &str) -> CanDo {
         use self::CanDo::*;
 
-        Ok(match s {
+        match s {
             "sendVstEvents" => SendEvents,
             "sendVstMidiEvent" => SendMidiEvent,
             "receiveVstEvents" => ReceiveEvents,
@@ -416,7 +415,7 @@ impl FromStr for CanDo {
             "midiSingleNoteTuningChange" => MidiSingleNoteTuningChange,
             "midiKeyBasedInstrumentControl" => MidiKeyBasedInstrumentControl,
             otherwise => Other(otherwise.to_string()),
-        })
+        }
     }
 }
 


### PR DESCRIPTION
`CanDo::from_str` was implemented in such a way that it was infallible, but the return type was still `Result<CanDo, String>`. Maybe the code was written like this to allow extending it to fail later? But if not, I thought it could be simplified and make the method more exactly express what it returns. This then also simplifies its usage.