### PR TITLE
Follow up on PR #32 to implement GetTimeInfo and others

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -662,6 +662,7 @@ pub struct SysExEvent {
 }
 
 #[repr(C)]
+#[derive(Clone)]
 /// Describes the time at the start of the block currently being processed
 pub struct TimeInfo {
     /// current Position in audio samples (always valid)

--- a/src/api.rs
+++ b/src/api.rs
@@ -662,7 +662,7 @@ pub struct SysExEvent {
 }
 
 #[repr(C)]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 /// Describes the time at the start of the block currently being processed
 pub struct TimeInfo {
     /// current Position in audio samples (always valid)
@@ -739,7 +739,12 @@ pub enum SmpteFrameRate {
     /// HDTV: 59.94 fps
     Smpte599fps = 12,
     /// HDTV: 60 fps
-    Smpte60fps = 13
+    Smpte60fps = 13,
+}
+impl Default for SmpteFrameRate {
+    fn default() -> Self {
+        SmpteFrameRate::Smpte24fps
+    }
 }
 
 /// Bitflags.

--- a/src/api.rs
+++ b/src/api.rs
@@ -661,6 +661,86 @@ pub struct SysExEvent {
     pub _reserved2: isize,
 }
 
+#[repr(C)]
+/// Describes the time at the start of the block currently being processed
+pub struct TimeInfo {
+    /// current Position in audio samples (always valid)
+    pub sample_pos: f64,
+
+    /// current Sample Rate in Hertz (always valid)
+    pub sample_rate: f64,
+
+    /// System Time in nanoseconds (10^-9 second)
+    pub nanoseconds: f64,
+
+    /// Musical Position, in Quarter Note (1.0 equals 1 Quarter Note)
+    pub ppq_pos: f64,
+
+    /// current Tempo in BPM (Beats Per Minute)
+    pub tempo: f64,
+
+    /// last Bar Start Position, in Quarter Note
+    pub bar_start_pos: f64,
+
+    /// Cycle Start (left locator), in Quarter Note
+    pub cycle_start_pos: f64,
+    
+    /// Cycle End (right locator), in Quarter Note
+    pub cycle_end_pos: f64,
+
+    /// Time Signature Numerator (e.g. 3 for 3/4)
+    pub time_sig_numerator: i32,
+
+    /// Time Signature Denominator (e.g. 4 for 3/4)
+    pub time_sig_denominator: i32,
+
+    /// SMPTE offset in SMPTE subframes (bits; 1/80 of a frame).
+    /// The current SMPTE position can be calculated using `sample_pos`, `sample_rate`, and `smpte_frame_rate`.
+    pub smpte_offset: i32,
+
+    /// See `SmpteFrameRate`
+    pub smpte_frame_rate: SmpteFrameRate,
+
+    /// MIDI Clock Resolution (24 Per Quarter Note), can be negative (nearest clock)
+    pub samples_to_next_clock: i32,
+
+    /// See `flags::TimeInfo`
+    pub flags: i32
+}
+
+#[repr(i32)]
+#[derive(Copy, Clone, Debug)]
+/// SMPTE Frame Rates.
+pub enum SmpteFrameRate {
+    /// 24 fps
+    Smpte24fps = 0,
+    /// 25 fps
+    Smpte25fps = 1,
+    /// 29.97 fps
+    Smpte2997fps = 2,
+    /// 30 fps
+    Smpte30fps = 3,
+
+    /// 29.97 drop
+    Smpte2997dfps = 4,
+    /// 30 drop
+    Smpte30dfps = 5,
+
+    /// Film 16mm
+    SmpteFilm16mm = 6,
+    /// Film 35mm
+    SmpteFilm35mm = 7,
+
+    /// HDTV: 23.976 fps
+    Smpte239fps = 10,
+    /// HDTV: 24.976 fps
+    Smpte249fps = 11,
+    /// HDTV: 59.94 fps
+    Smpte599fps = 12,
+    /// HDTV: 60 fps
+    Smpte60fps = 13
+}
+
 /// Bitflags.
 pub mod flags {
     bitflags! {
@@ -714,6 +794,42 @@ pub mod flags {
             /// plugin to handle these flagged events with higher priority, especially when the
             /// plugin has a big latency as per `plugin::Info::initial_delay`.
             const REALTIME_EVENT = 1,
+        }
+    }
+
+    bitflags! {
+        /// Used in the `flags` field of `TimeInfo`, and for querying the host for specific values
+        pub flags TimeInfo : i32 {
+            /// Indicates that play, cycle or record state has changed.
+            const TRANSPORT_CHANGED = 1,
+            /// Set if Host sequencer is currently playing.
+            const TRANSPORT_PLAYING = 1 << 1,
+            /// Set if Host sequencer is in cycle mode.
+            const TRANSPORT_CYCLE_ACTIVE = 1 << 2,
+            /// Set if Host sequencer is in record mode.
+            const TRANSPORT_RECORDING = 1 << 3,
+
+            /// Set if automation write mode active (record parameter changes).
+            const AUTOMATION_WRITING = 1 << 6,
+            /// Set if automation read mode active (play parameter changes).
+            const AUTOMATION_READING = 1 << 7,
+
+            /// Set if TimeInfo::nanoseconds is valid.
+            const NANOSECONDS_VALID = 1 << 8,
+            /// Set if TimeInfo::ppq_pos is valid.
+            const PPQ_POS_VALID = 1 << 9,
+            /// Set if TimeInfo::tempo is valid.
+            const TEMPO_VALID = 1 << 10,
+            /// Set if TimeInfo::bar_start_pos is valid.
+            const BARS_VALID = 1 << 11,
+            /// Set if both TimeInfo::cycle_start_pos and VstTimeInfo::cycle_end_pos are valid.
+            const CYCLE_POS_VALID = 1 << 12,
+            /// Set if both TimeInfo::time_sig_numerator and TimeInfo::time_sig_denominator are valid.
+            const TIME_SIG_VALID = 1 << 13,
+            /// Set if both TimeInfo::smpte_offset and VstTimeInfo::smpte_frame_rate are valid.
+            const SMPTE_VALID = 1 << 14,
+            /// Set if TimeInfo::samples_to_next_clock is valid.
+            const VST_CLOCK_VALID = 1 << 15
         }
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -662,7 +662,7 @@ pub struct SysExEvent {
 }
 
 #[repr(C)]
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Copy)]
 /// Describes the time at the start of the block currently being processed
 pub struct TimeInfo {
     /// current Position in audio samples (always valid)

--- a/src/host.rs
+++ b/src/host.rs
@@ -404,6 +404,9 @@ impl PluginInstance {
                 inputs: effect.numInputs,
                 outputs: effect.numOutputs,
 
+                midi_inputs: 0,
+                midi_outputs: 0,
+
                 unique_id: effect.uniqueId,
                 version: effect.version,
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -13,7 +13,7 @@ use std::os::raw::c_void;
 
 use interfaces;
 use plugin::{self, Plugin, Info, Category};
-use api::{self, AEffect, PluginMain, Supported};
+use api::{self, AEffect, PluginMain, Supported, TimeInfo};
 use api::consts::*;
 use buffer::AudioBuffer;
 use channels::ChannelInfo;
@@ -211,6 +211,11 @@ pub trait Host {
 
     /// Handle incoming events from the plugin.
     fn process_events(&mut self, events: &api::Events) {}
+
+    /// Get time information.
+    fn get_time_info(&self, mask: i32) -> Option<TimeInfo> {
+        None
+    }
 }
 
 /// All possible errors that can occur when loading a VST plugin.

--- a/src/host.rs
+++ b/src/host.rs
@@ -216,6 +216,11 @@ pub trait Host {
     fn get_time_info(&self, mask: i32) -> Option<TimeInfo> {
         None
     }
+
+    /// Get block size.
+    fn get_block_size(&self) -> isize {
+        0
+    }
 }
 
 /// All possible errors that can occur when loading a VST plugin.

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -288,6 +288,12 @@ pub fn dispatch(
         OpCode::StartProcess => plugin.start_process(),
         OpCode::StopProcess => plugin.stop_process(),
 
+        OpCode::GetNumMidiInputs => {
+            return plugin.get_info().midi_inputs as isize;
+        }
+        OpCode::GetNumMidiOutputs => {
+            return plugin.get_info().midi_outputs as isize;
+        }
 
         _ => {
             debug!("Unimplemented opcode ({:?})", opcode);

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -3,7 +3,7 @@
 #![doc(hidden)]
 
 use std::{mem, slice};
-use std::cell::UnsafeCell;
+use std::cell::Cell;
 use std::os::raw::{c_char, c_void};
 
 use buffer::AudioBuffer;
@@ -346,12 +346,12 @@ pub fn host_dispatch(
                 None => 0,
                 Some(result) => {
                     thread_local! {
-                        static TIME_INFO: UnsafeCell<TimeInfo> =
-                            UnsafeCell::new(unsafe { mem::uninitialized() });
+                        static TIME_INFO: Cell<TimeInfo> =
+                            Cell::new(TimeInfo::default());
                     }
                     TIME_INFO.with(|time_info| {
-                        unsafe { *time_info.get() = result };
-                        time_info.get() as isize
+                        (*time_info).set(result);
+                        time_info.as_ptr() as isize
                     })
                 }
             };

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -285,6 +285,10 @@ pub fn dispatch(
             }
         }
 
+        OpCode::StartProcess => plugin.start_process(),
+        OpCode::StopProcess => plugin.stop_process(),
+
+
         _ => {
             debug!("Unimplemented opcode ({:?})", opcode);
             trace!(

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -356,6 +356,7 @@ pub fn host_dispatch(
                 }
             };
         }
+        OpCode::GetBlockSize => return host.get_block_size(),
 
         unimplemented => {
             trace!("VST: Got unimplemented host opcode ({:?})", unimplemented);

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -289,10 +289,10 @@ pub fn dispatch(
         OpCode::StopProcess => plugin.stop_process(),
 
         OpCode::GetNumMidiInputs => {
-            return plugin.get_info().midi_inputs as isize;
+            return unsafe { (*effect).get_cache() }.info.midi_inputs as isize
         }
         OpCode::GetNumMidiOutputs => {
-            return plugin.get_info().midi_outputs as isize;
+            return unsafe { (*effect).get_cache() }.info.midi_outputs as isize
         }
 
         _ => {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -947,7 +947,7 @@ impl Host for HostCallback {
 
         match ptr {
             0   => None,
-            ptr => Some(unsafe { (*(ptr as *const TimeInfo)).clone() }),
+            ptr => Some(unsafe { (*(ptr as *const TimeInfo)) }),
         }
     }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -954,6 +954,11 @@ impl Host for HostCallback {
             ptr => Some(unsafe { (*(ptr as *const TimeInfo)).clone() }),
         }
     }
+
+    /// Get block size.
+    fn get_block_size(&self) -> isize {
+        self.callback(self.effect, host::OpCode::GetBlockSize, 0, 0, ptr::null_mut(), 0.0)
+    }
 }
 
 #[cfg(test)]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -855,35 +855,6 @@ impl HostCallback {
             .take_while(|c| *c != '\0')
             .collect()
     }
-
-    /// Request time information from Host.
-    /// 
-    /// The mask parameter is composed of the same flags which will be found in the `flags` field of `TimeInfo` when returned.
-    /// That is, if you want the host's tempo, the parameter passed to `get_time_info()` should have the `TEMPO_VALID` flag set.
-    /// This request and delivery system is important, as a request like this may cause
-    /// significant calculations at the application's end, which may take a lot of our precious time.
-    /// This obviously means you should only set those flags that are required to get the information you need.
-    ///
-    /// Also please be aware that requesting information does not necessarily mean that that information is provided in return.
-    /// Check the flags field in the `TimeInfo` structure to see if your request was actually met.
-    #[allow(unused)]
-    pub fn get_time_info(&self, mask: i32) -> Option<TimeInfo> {
-        if self.callback.is_none() {
-            return None
-        }
-        
-        let opcode = host::OpCode::GetTime;
-        let mask = mask as isize;
-        let null = 0 as *mut c_void;
-        let ptr = self.callback(self.effect, opcode, 0, mask, null, 0.0);
-
-        match ptr {
-            0 => None,
-            ptr => Some(unsafe {
-                mem::transmute_copy(&*(ptr as *const TimeInfo))
-            })
-        }
-    }
 }
 
 impl Host for HostCallback {
@@ -947,6 +918,32 @@ impl Host for HostCallback {
             events as *const _ as *mut _,
             0.0,
         );
+    }
+
+    /// Request time information from Host.
+    ///
+    /// The mask parameter is composed of the same flags which will be found in the `flags` field of `TimeInfo` when returned.
+    /// That is, if you want the host's tempo, the parameter passed to `get_time_info()` should have the `TEMPO_VALID` flag set.
+    /// This request and delivery system is important, as a request like this may cause
+    /// significant calculations at the application's end, which may take a lot of our precious time.
+    /// This obviously means you should only set those flags that are required to get the information you need.
+    ///
+    /// Also please be aware that requesting information does not necessarily mean that that information is provided in return.
+    /// Check the flags field in the `TimeInfo` structure to see if your request was actually met.
+    fn get_time_info(&self, mask: i32) -> Option<TimeInfo> {
+        if self.callback.is_none() {
+            return None
+        }
+
+        let opcode = host::OpCode::GetTime;
+        let mask = mask as isize;
+        let null = 0 as *mut c_void;
+        let ptr = self.callback(self.effect, opcode, 0, mask, null, 0.0);
+
+        match ptr {
+            0   => None,
+            ptr => Some(unsafe { (*(ptr as *const TimeInfo)).clone() }),
+        }
     }
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -315,6 +315,12 @@ pub struct Info {
     /// Number of outputs.
     pub outputs: i32,
 
+    /// Number of MIDI input channels (1-16), or 0 for the default of 16 channels.
+    pub midi_inputs: i32,
+
+    /// Number of MIDI output channels (1-16), or 0 for the default of 16 channels.
+    pub midi_outputs: i32,
+
     /// Unique plugin ID. Can be registered with Steinberg to prevent conflicts with other plugins.
     ///
     /// This ID is used to identify a plugin during save and load of a preset and project.
@@ -359,6 +365,9 @@ impl Default for Info {
             parameters: 0,
             inputs: 2, // Stereo in,out
             outputs: 2,
+
+            midi_inputs: 0,
+            midi_outputs: 0,
 
             unique_id: 0, // This must be changed.
             version: 1, // v0.0.0.1

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -716,6 +716,13 @@ pub trait Plugin {
             None,
         )
     }
+
+    /// Called one time before the start of process call.
+    /// This indicates that the process call will be interrupted (due to Host reconfiguration or bypass state when the plug-in doesn't support softBypass).
+    fn start_process(&self) {}
+
+    /// Called after the stop of process call.
+    fn stop_process(&self) {}
 }
 
 /// A reference to the host which allows the plugin to call back and access information.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -940,10 +940,6 @@ impl Host for HostCallback {
     /// Also please be aware that requesting information does not necessarily mean that that information is provided in return.
     /// Check the flags field in the `TimeInfo` structure to see if your request was actually met.
     fn get_time_info(&self, mask: i32) -> Option<TimeInfo> {
-        if self.callback.is_none() {
-            return None
-        }
-
         let opcode = host::OpCode::GetTime;
         let mask = mask as isize;
         let null = 0 as *mut c_void;


### PR DESCRIPTION
This PR implements @Boscop's suggestions from #32 .
I would also propose to implement a time signature type like [time_calc's TimeSig](https://docs.rs/time_calc/0.13.0/time_calc/time_sig/struct.TimeSig.html)  to make `TimeInfo` a bit more high-level.

Closes #32.