### PR TITLE
Fix is_effect_valid check

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -802,7 +802,7 @@ impl HostCallback {
     #[doc(hidden)]
     fn is_effect_valid(&self) -> bool {
         // Check whether `effect` points to a valid AEffect struct
-        self.effect as i32 == VST_MAGIC
+        unsafe { *(self.effect as *mut i32) == VST_MAGIC }
     }
 
     /// Create a new Host structure wrapping a host callback.


### PR DESCRIPTION
I noticed yesterday that the `automate` host callbacks I was performing in [Oidos](https://github.com/askeksa/Oidos) had seemingly stopped working. I traced the fault back to [this change](https://github.com/rust-dsp/rust-vst/commit/b124fefab71db5e5f3bfb4e293d3756f2fba810a#diff-538e35b483f0e8440309b5f03379e387R805) which broke the `is_effect_valid` check and thus caused all callback calls guarded by this check to do nothing.

I am a bit unsure how to write a test for this function, as it involves the bridging code and depends on the shape of an actual, loaded plugin.