### PR TITLE
Fix HostCallback::is_effect_valid()

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -802,7 +802,7 @@ impl HostCallback {
     #[doc(hidden)]
     fn is_effect_valid(&self) -> bool {
         // Check whether `effect` points to a valid AEffect struct
-        self.effect as i32 == VST_MAGIC
+        unsafe { (*self.effect).magic as i32 == VST_MAGIC }
     }
 
     /// Create a new Host structure wrapping a host callback.


### PR DESCRIPTION
`is_effect_valid()` was turning `*mut AEffect` itself into an `i32` and comparing it with `VST_MAGIC`.

What needs to happen instead is you need to fetch `magic` out of the `AEffect` struct and compare *that* with `VST_MAGIC`.

I believe this is the more correct way of doing it over what #64 and #47 have.

Also, comments in Telegram suggest we might just be able to remove the function entirely, which I can do if that's the desired change.

I tested this as part of my X11 GUI development - before this change, parameters were not updating in the DAW when you changed them via the GUI; after this change, they updated successfully.