### PR TITLE
OpCode::EditorOpen: return 1 if editor opened successfully

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A library to help facilitate creating VST plugins in rust.
 This library is a work in progress and as such does not yet implement all
 opcodes. It is enough to create basic VST plugins without an editor interface.
 
-For more detailed information about this library and subtopics such as GUI development progress, please check the [wiki](https://github.com/rust-dsp/rust-vst/wiki/Rust-Audio-GUI-Development-Progress#events-and-threads).
+For more detailed information about this library and subtopics such as GUI development progress, please check the [wiki](https://github.com/rust-dsp/rust-vst/wiki/).
 
 ## Library Documentation
   * https://rust-dsp.github.io/rust-vst

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -11,20 +11,28 @@ pub trait Editor {
     /// Get the coordinates of the editor window.
     fn position(&self) -> (i32, i32);
 
-
     /// Editor idle call. Called by host.
     fn idle(&mut self) {}
 
     /// Called when the editor window is closed.
     fn close(&mut self) {}
 
-    /// Called when the editor window is opened. `window` is a platform dependent window pointer
-    /// (e.g. `HWND` on Windows, `WindowRef` on OSX, `Window` on X11/Linux).
-    fn open(&mut self, window: *mut c_void);
+    /// Called when the editor window is opened.
+    ///
+    /// `parent` is a window pointer that the new window should attach itself to.
+    /// **It is dependent upon the platform you are targeting.**
+    ///
+    /// A few examples:
+    ///
+    ///  - On Windows, it should be interpreted as a `HWND`
+    ///  - On Mac OS X (64 bit), it should be interpreted as a `NSView*`
+    ///  - On X11 platforms, it should be interpreted as a `u32` (the ID number of the parent window)
+    ///
+    /// Return true if the window opened successfully, false otherwise.
+    fn open(&mut self, parent: *mut c_void) -> bool;
 
     /// Return whether the window is currently open.
     fn is_open(&mut self) -> bool;
-
 
     /// Set the knob mode for this editor (if supported by host).
     ///
@@ -33,7 +41,7 @@ pub trait Editor {
         false
     }
 
-    /// Recieve key up event. Return true if the key was used.
+    /// Receive key up event. Return true if the key was used.
     fn key_up(&mut self, keycode: KeyCode) -> bool {
         false
     }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -28,7 +28,7 @@ pub trait Editor {
     ///  - On Mac OS X (64 bit), it should be interpreted as a `NSView*`
     ///  - On X11 platforms, it should be interpreted as a `u32` (the ID number of the parent window)
     ///
-    /// Return true if the window opened successfully, false otherwise.
+    /// Return `true` if the window opened successfully, `false` otherwise.
     fn open(&mut self, parent: *mut c_void) -> bool;
 
     /// Return whether the window is currently open.
@@ -36,17 +36,17 @@ pub trait Editor {
 
     /// Set the knob mode for this editor (if supported by host).
     ///
-    /// Return true if the knob mode was set.
+    /// Return `true` if the knob mode was set.
     fn set_knob_mode(&mut self, mode: KnobMode) -> bool {
         false
     }
 
-    /// Receive key up event. Return true if the key was used.
+    /// Receive key up event. Return `true` if the key was used.
     fn key_up(&mut self, keycode: KeyCode) -> bool {
         false
     }
 
-    /// Receive key down event. Return true if the key was used.
+    /// Receive key down event. Return `true` if the key was used.
     fn key_down(&mut self, keycode: KeyCode) -> bool {
         false
     }

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -165,6 +165,7 @@ pub fn dispatch(
         OpCode::EditorOpen => {
             if let Some(editor) = plugin.get_editor() {
                 editor.open(ptr); //ptr is raw window handle, eg HWND* on windows
+                return 1;
             }
         }
         OpCode::EditorClose => {

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -164,8 +164,9 @@ pub fn dispatch(
         }
         OpCode::EditorOpen => {
             if let Some(editor) = plugin.get_editor() {
-                editor.open(ptr); //ptr is raw window handle, eg HWND* on windows
-                return 1;
+                // `ptr` is a window handle to the parent window.
+                // See the documentation for `Editor::open` for details.
+                if editor.open(ptr) { return 1; }
             }
         }
         OpCode::EditorClose => {


### PR DESCRIPTION
`dispatch()` should return 1 if the editor was opened successfully. Some DAWs ignore this return value, but others don't.

One example of a DAW that doesn't is Carla ([see this chunk of code](https://github.com/falkTX/Carla/blob/51f20736b4e0b5d6416f2b7d4051f155f5858fbf/source/backend/plugin/CarlaPluginVST2.cpp#L513)).

Since we return 0 here by default, Carla assumes that the editor failed to open.

I think the more correct way to do this would be to actually check that `editor.open()` was successful in some way, but that would require an API change.