### PR TITLE
Update lints

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -148,7 +148,7 @@ impl AEffect {
     /// Return handle to Plugin object. Only works for plugins created using this library.
     // Supresses warning about returning a reference to a box
     #[allow(unknown_lints)]
-    #[allow(borrowed_box)]
+    #[allow(clippy::borrowed_box)]
     pub unsafe fn get_plugin(&mut self) -> &mut Box<Plugin> {
         //FIXME: find a way to do this without resorting to transmuting via a box
         &mut *(self.object as *mut Box<Plugin>)

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -413,7 +413,7 @@ impl SendEventBuffer {
 
     #[inline(always)]
     fn events(&self) -> &api::Events {
-        #[allow(cast_ptr_alignment)]
+        #[allow(clippy::cast_ptr_alignment)]
         unsafe {
             &*(self.buf.as_ptr() as *const api::Events)
         }
@@ -421,7 +421,7 @@ impl SendEventBuffer {
 
     #[inline(always)]
     fn buf_as_api_events(buf: &mut [u8]) -> &mut api::Events {
-        #[allow(cast_ptr_alignment)]
+        #[allow(clippy::cast_ptr_alignment)]
         unsafe {
             &mut *(buf.as_mut_ptr() as *mut api::Events)
         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -113,7 +113,7 @@ impl<'a> From<api::Event> for Event<'a> {
                 payload: unsafe {
                     // We can safely transmute the event pointer to a `SysExEvent` pointer as
                     // event_type refers to a `SysEx` type.
-                    #[allow(cast_ptr_alignment)]
+                    #[allow(clippy::cast_ptr_alignment)]
                     let event: &api::SysExEvent =
                         &*(&event as *const api::Event as *const api::SysExEvent);
                     slice::from_raw_parts(event.system_data, event.data_size as usize)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,6 @@ pub fn main<T: Plugin + Default>(callback: HostCallbackProc) -> *mut AEffect {
 }
 
 #[cfg(test)]
-#[allow(private_no_mangle_fns)] // For `plugin_main!`
 mod tests {
     use std::ptr;
 


### PR DESCRIPTION
The following three lints give me a bunch of output every time I build `rust-vst`:

```
warning: lint name `borrowed_box` is deprecated and may not have an effect in the future.
Also `cfg_attr(cargo-clippy)` won't be necessary anymore

help: change it to: `clippy::borrowed_box`



warning: lint name `cast_ptr_alignment` is deprecated and may not have an effect in the future.
Also `cfg_attr(cargo-clippy)` won't be necessary anymore

help: change it to: `clippy::cast_ptr_alignment`



warning: lint `private_no_mangle_fns` has been removed:
`no longer an warning, #[no_mangle] functions always exported`
```

The above is output from Clippy, but whenever I did `cargo build` it would warn me about unknown lints.

This change updates those lints so that the build is a little more quiet.