### PR TITLE
Update CI builds to use stable only

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,18 +44,18 @@ environment:
     - channel: stable
       target: i686-pc-windows-msvc
   # Beta 64-bit MSVC
-    - channel: beta
-      target: x86_64-pc-windows-msvc
+    # - channel: beta
+    #   target: x86_64-pc-windows-msvc
   # Beta 32-bit MSVC
-    - channel: beta
-      target: i686-pc-windows-msvc
+    # - channel: beta
+    #   target: i686-pc-windows-msvc
   # Nightly 64-bit MSVC
-    - channel: nightly
-      target: x86_64-pc-windows-msvc
+    # - channel: nightly
+    #   target: x86_64-pc-windows-msvc
       #cargoflags: --features "unstable"
   # Nightly 32-bit MSVC
-    - channel: nightly
-      target: i686-pc-windows-msvc
+    # - channel: nightly
+    #   target: i686-pc-windows-msvc
       #cargoflags: --features "unstable"
 
 ### GNU Toolchains ###
@@ -67,18 +67,18 @@ environment:
     - channel: stable
       target: i686-pc-windows-gnu
   # Beta 64-bit GNU
-    - channel: beta
-      target: x86_64-pc-windows-gnu
+    # - channel: beta
+    #   target: x86_64-pc-windows-gnu
   # Beta 32-bit GNU
-    - channel: beta
-      target: i686-pc-windows-gnu
+    # - channel: beta
+    #   target: i686-pc-windows-gnu
   # Nightly 64-bit GNU
-    - channel: nightly
-      target: x86_64-pc-windows-gnu
+    # - channel: nightly
+    #   target: x86_64-pc-windows-gnu
       #cargoflags: --features "unstable"
   # Nightly 32-bit GNU
-    - channel: nightly
-      target: i686-pc-windows-gnu
+    # - channel: nightly
+    #   target: i686-pc-windows-gnu
       #cargoflags: --features "unstable"
 
 ### Allowed failures ###

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,20 @@ jobs:
   include:
     - stage: test
       os: linux
+      before_script:
+        - rustup toolchain install stable
+        - rustup component add --toolchain stable clippy-preview || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
       script:
-        - rustup toolchain install nightly
-        - rustup component add --toolchain nightly clippy
-        - cargo +nightly clippy
+        - cargo +stable clippy
         - cargo build --verbose
         - cargo test --verbose
     - 
       os: osx
+      before_script:
+        - rustup toolchain install stable
+        - rustup component add --toolchain stable clippy-preview || cargo install --git https://github.com/rust-lang/rust-clippy/ --force clippy
       script:
-        - rustup toolchain install nightly
-        - rustup component add --toolchain nightly clippy
-        - cargo +nightly clippy
+        - cargo +stable clippy
         - cargo build --verbose
         - cargo test --verbose
         

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jobs:
       os: linux
       script:
         - rustup toolchain install nightly
-        - rustup component add --toolchain=nightly clippy
+        - rustup component add --toolchain nightly clippy
         - cargo +nightly clippy
         - cargo build --verbose
         - cargo test --verbose
@@ -13,7 +13,7 @@ jobs:
       os: osx
       script:
         - rustup toolchain install nightly
-        - rustup component add --toolchain=nightly clippy
+        - rustup component add --toolchain nightly clippy
         - cargo +nightly clippy
         - cargo build --verbose
         - cargo test --verbose


### PR DESCRIPTION
Looks like the toolchain specification syntax we were using previously no longer works