### PR TITLE
Utility structs to make it easier to make plugins thread safe.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ libloading = "0.5"
 
 [dev-dependencies]
 time = "0.1"
+rand = "0.6.5"
 
 [[example]]
 name = "dimension_expander"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,8 @@ pub mod plugin;
 mod interfaces;
 mod cache;
 
+pub mod util;
+
 use api::{HostCallbackProc, AEffect};
 use api::consts::VST_MAGIC;
 use plugin::{HostCallback, Plugin};

--- a/src/util/atomic_float.rs
+++ b/src/util/atomic_float.rs
@@ -1,0 +1,30 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Simple atomic floating point variable with relaxed ordering.
+///
+/// Designed for the common case of sharing VST parameters between
+/// multiple threads when no synchronization or change notification
+/// is needed.
+pub struct AtomicFloat {
+    // TODO: Change atomic to AtomicU32 when stabilized (expected in 1.34).
+    atomic: AtomicUsize,
+}
+
+impl AtomicFloat {
+    /// New atomic float with initial value `value`.
+    pub fn new(value: f32) -> AtomicFloat {
+        AtomicFloat {
+            atomic: AtomicUsize::new(value.to_bits() as usize),
+        }
+    }
+
+    /// Get the current value of the atomic float.
+    pub fn get(&self) -> f32 {
+        f32::from_bits(self.atomic.load(Ordering::Relaxed) as u32)
+    }
+
+    /// Set the value of the atomic float to `value`.
+    pub fn set(&self, value: f32) {
+        self.atomic.store(value.to_bits() as usize, Ordering::Relaxed)
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,7 @@
+//! Structures for easing the implementation of VST plugins.
+
+mod atomic_float;
+mod parameter_transfer;
+
+pub use self::atomic_float::AtomicFloat;
+pub use self::parameter_transfer::{ParameterTransfer, ParameterTransferIterator};

--- a/src/util/parameter_transfer.rs
+++ b/src/util/parameter_transfer.rs
@@ -45,10 +45,15 @@ impl ParameterTransfer {
 	///
 	/// The iterator returns a pair of `(index, value)` for each changed parameter.
 	///
-	/// The iterator is conservative is the sense that it is guaranteed to report
-	/// changed parameters, but if a parameter is changed multiple times in a short
-	/// period of time, it may skip some of the changes (but never the last) and
-	/// may report an extra, spurious change at the end.
+	/// When parameters have been changed on the current thread, the iterator is
+	/// precise: it reports all changed parameters with the values they were last
+	/// changed to.
+	///
+	/// When parameters are changed on a different thread, the iterator is
+	/// conservative, in the sense that it is guaranteed to report changed
+	/// parameters eventually, but if a parameter is changed multiple times in
+	/// a short period of time, it may skip some of the changes (but never the
+	/// last) and may report an extra, spurious change at the end.
 	///
 	/// The changed parameters are reported in increasing index order, and the same
 	/// parameter is never reported more than once in the same iteration.

--- a/src/util/parameter_transfer.rs
+++ b/src/util/parameter_transfer.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 const USIZE_BITS: usize = size_of::<usize>() * 8;
 
 fn word_and_bit(index: usize) -> (usize, usize) {
-	(index / USIZE_BITS, 1usize << (index & (USIZE_BITS - 1)))
+    (index / USIZE_BITS, 1usize << (index & (USIZE_BITS - 1)))
 }
 
 /// A set of parameters that can be shared between threads.
@@ -12,175 +12,175 @@ fn word_and_bit(index: usize) -> (usize, usize) {
 /// Supports efficient iteration over parameters that changed since last iteration.
 #[derive(Default)]
 pub struct ParameterTransfer {
-	// TODO: Change values to AtomicU32 when stabilized (expected in 1.34).
-	values: Vec<AtomicUsize>,
-	changed: Vec<AtomicUsize>,
+    // TODO: Change values to AtomicU32 when stabilized (expected in 1.34).
+    values: Vec<AtomicUsize>,
+    changed: Vec<AtomicUsize>,
 }
 
 impl ParameterTransfer {
-	/// Create a new parameter set with `parameter_count` parameters.
-	pub fn new(parameter_count: usize) -> Self {
-		let bit_words = (parameter_count + USIZE_BITS - 1) / USIZE_BITS;
-		ParameterTransfer {
-			values: (0..parameter_count).map(|_| AtomicUsize::new(0)).collect(),
-			changed: (0..bit_words).map(|_| AtomicUsize::new(0)).collect(),
-		}
-	}
+    /// Create a new parameter set with `parameter_count` parameters.
+    pub fn new(parameter_count: usize) -> Self {
+        let bit_words = (parameter_count + USIZE_BITS - 1) / USIZE_BITS;
+        ParameterTransfer {
+            values: (0..parameter_count).map(|_| AtomicUsize::new(0)).collect(),
+            changed: (0..bit_words).map(|_| AtomicUsize::new(0)).collect(),
+        }
+    }
 
-	/// Set the value of the parameter with index `index` to `value` and mark
-	/// it as changed.
-	pub fn set_parameter(&self, index: usize, value: f32) {
-		let (word, bit) = word_and_bit(index);
-		self.values[index].store(value.to_bits() as usize, Ordering::Relaxed);
-		self.changed[word].fetch_or(bit, Ordering::AcqRel);
-	}
+    /// Set the value of the parameter with index `index` to `value` and mark
+    /// it as changed.
+    pub fn set_parameter(&self, index: usize, value: f32) {
+        let (word, bit) = word_and_bit(index);
+        self.values[index].store(value.to_bits() as usize, Ordering::Relaxed);
+        self.changed[word].fetch_or(bit, Ordering::AcqRel);
+    }
 
-	/// Get the current value of the parameter with index `index`.
-	pub fn get_parameter(&self, index: usize) -> f32 {
-		f32::from_bits(self.values[index].load(Ordering::Relaxed) as u32)
-	}
+    /// Get the current value of the parameter with index `index`.
+    pub fn get_parameter(&self, index: usize) -> f32 {
+        f32::from_bits(self.values[index].load(Ordering::Relaxed) as u32)
+    }
 
-	/// Iterate over all parameters marked as changed. If `acquire` is `true`,
-	/// mark all returned parameters as no longer changed.
-	///
-	/// The iterator returns a pair of `(index, value)` for each changed parameter.
-	///
-	/// When parameters have been changed on the current thread, the iterator is
-	/// precise: it reports all changed parameters with the values they were last
-	/// changed to.
-	///
-	/// When parameters are changed on a different thread, the iterator is
-	/// conservative, in the sense that it is guaranteed to report changed
-	/// parameters eventually, but if a parameter is changed multiple times in
-	/// a short period of time, it may skip some of the changes (but never the
-	/// last) and may report an extra, spurious change at the end.
-	///
-	/// The changed parameters are reported in increasing index order, and the same
-	/// parameter is never reported more than once in the same iteration.
-	pub fn iterate<'pt>(&'pt self, acquire: bool) -> ParameterTransferIterator<'pt> {
-		ParameterTransferIterator {
-			pt: self,
-			word: 0,
-			bit: 1,
-			acquire,
-		}
-	}
+    /// Iterate over all parameters marked as changed. If `acquire` is `true`,
+    /// mark all returned parameters as no longer changed.
+    ///
+    /// The iterator returns a pair of `(index, value)` for each changed parameter.
+    ///
+    /// When parameters have been changed on the current thread, the iterator is
+    /// precise: it reports all changed parameters with the values they were last
+    /// changed to.
+    ///
+    /// When parameters are changed on a different thread, the iterator is
+    /// conservative, in the sense that it is guaranteed to report changed
+    /// parameters eventually, but if a parameter is changed multiple times in
+    /// a short period of time, it may skip some of the changes (but never the
+    /// last) and may report an extra, spurious change at the end.
+    ///
+    /// The changed parameters are reported in increasing index order, and the same
+    /// parameter is never reported more than once in the same iteration.
+    pub fn iterate<'pt>(&'pt self, acquire: bool) -> ParameterTransferIterator<'pt> {
+        ParameterTransferIterator {
+            pt: self,
+            word: 0,
+            bit: 1,
+            acquire,
+        }
+    }
 }
 
 /// An iterator over changed parameters.
 /// Returned by [`iterate`](struct.ParameterTransfer.html#method.iterate).
 pub struct ParameterTransferIterator<'pt> {
-	pt: &'pt ParameterTransfer,
-	word: usize,
-	bit: usize,
-	acquire: bool,
+    pt: &'pt ParameterTransfer,
+    word: usize,
+    bit: usize,
+    acquire: bool,
 }
 
 impl<'pt> Iterator for ParameterTransferIterator<'pt> {
-	type Item = (usize, f32);
+    type Item = (usize, f32);
 
-	fn next(&mut self) -> Option<(usize, f32)> {
-		let bits = loop {
-			if self.word == self.pt.changed.len() {
-				return None
-			}
-			let bits = self.pt.changed[self.word].load(Ordering::Acquire) & self.bit.wrapping_neg();
-			if bits != 0 { break bits; }
-			self.word += 1;
-			self.bit = 1;
-		};
+    fn next(&mut self) -> Option<(usize, f32)> {
+        let bits = loop {
+            if self.word == self.pt.changed.len() {
+                return None
+            }
+            let bits = self.pt.changed[self.word].load(Ordering::Acquire) & self.bit.wrapping_neg();
+            if bits != 0 { break bits; }
+            self.word += 1;
+            self.bit = 1;
+        };
 
-		let bit_index = bits.trailing_zeros() as usize;
-		let bit = 1usize << bit_index;
-		let index = self.word * USIZE_BITS + bit_index;
+        let bit_index = bits.trailing_zeros() as usize;
+        let bit = 1usize << bit_index;
+        let index = self.word * USIZE_BITS + bit_index;
 
-		if self.acquire {
-			self.pt.changed[self.word].fetch_and(!bit, Ordering::AcqRel);
-		}
+        if self.acquire {
+            self.pt.changed[self.word].fetch_and(!bit, Ordering::AcqRel);
+        }
 
-		let next_bit = bit << 1;
-		if next_bit == 0 {
-			self.word += 1;
-			self.bit = 1;
-		} else {
-			self.bit = next_bit;
-		}
+        let next_bit = bit << 1;
+        if next_bit == 0 {
+            self.word += 1;
+            self.bit = 1;
+        } else {
+            self.bit = next_bit;
+        }
 
-		Some((index, self.pt.get_parameter(index)))
-	}
+        Some((index, self.pt.get_parameter(index)))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	extern crate rand;
+    extern crate rand;
 
-	use crate::util::ParameterTransfer;
+    use crate::util::ParameterTransfer;
 
-	use std::sync::Arc;
-	use std::sync::mpsc::channel;
-	use std::thread;
-	use std::time::Duration;
+    use std::sync::Arc;
+    use std::sync::mpsc::channel;
+    use std::thread;
+    use std::time::Duration;
 
-	use self::rand::{Rng, SeedableRng};
-	use self::rand::rngs::StdRng;
+    use self::rand::{Rng, SeedableRng};
+    use self::rand::rngs::StdRng;
 
-	const THREADS: usize = 3;
-	const PARAMETERS: usize = 1000;
-	const UPDATES: usize = 1000000;
+    const THREADS: usize = 3;
+    const PARAMETERS: usize = 1000;
+    const UPDATES: usize = 1000000;
 
-	#[test]
-	fn parameter_transfer() {
-		let transfer = Arc::new(ParameterTransfer::new(PARAMETERS));
-		let (tx, rx) = channel();
+    #[test]
+    fn parameter_transfer() {
+        let transfer = Arc::new(ParameterTransfer::new(PARAMETERS));
+        let (tx, rx) = channel();
 
-		// Launch threads that change parameters
-		for t in 0..THREADS {
-			let t_transfer = Arc::clone(&transfer);
-			let t_tx = tx.clone();
-			let mut t_rng = StdRng::seed_from_u64(t as u64);
-			thread::spawn(move || {
-				let mut values = vec![0f32; PARAMETERS];
-				for _ in 0..UPDATES {
-					let p: usize = t_rng.gen_range(0, PARAMETERS);
-					let v: f32 = t_rng.gen_range(0.0, 1.0);
-					values[p] = v;
-					t_transfer.set_parameter(p, v);
-				}
-				t_tx.send(values).unwrap();
-			});
-		}
+        // Launch threads that change parameters
+        for t in 0..THREADS {
+            let t_transfer = Arc::clone(&transfer);
+            let t_tx = tx.clone();
+            let mut t_rng = StdRng::seed_from_u64(t as u64);
+            thread::spawn(move || {
+                let mut values = vec![0f32; PARAMETERS];
+                for _ in 0..UPDATES {
+                    let p: usize = t_rng.gen_range(0, PARAMETERS);
+                    let v: f32 = t_rng.gen_range(0.0, 1.0);
+                    values[p] = v;
+                    t_transfer.set_parameter(p, v);
+                }
+                t_tx.send(values).unwrap();
+            });
+        }
 
-		// Continually receive updates from threads
-		let mut values = vec![0f32; PARAMETERS];
-		let mut results = vec![];
-		let mut acquire_rng = StdRng::seed_from_u64(42);
-		while results.len() < THREADS {
-			let mut last_p = -1;
-			for (p, v) in transfer.iterate(acquire_rng.gen_bool(0.9)) {
-				assert!(p as isize > last_p);
-				last_p = p as isize;
-				values[p] = v;
-			}
-			thread::sleep(Duration::from_micros(100));
-			while let Ok(result) = rx.try_recv() {
-				results.push(result);
-			}
-		}
+        // Continually receive updates from threads
+        let mut values = vec![0f32; PARAMETERS];
+        let mut results = vec![];
+        let mut acquire_rng = StdRng::seed_from_u64(42);
+        while results.len() < THREADS {
+            let mut last_p = -1;
+            for (p, v) in transfer.iterate(acquire_rng.gen_bool(0.9)) {
+                assert!(p as isize > last_p);
+                last_p = p as isize;
+                values[p] = v;
+            }
+            thread::sleep(Duration::from_micros(100));
+            while let Ok(result) = rx.try_recv() {
+                results.push(result);
+            }
+        }
 
-		// One last iteration to pick up all updates
-		let mut last_p = -1;
-		for (p, v) in transfer.iterate(true) {
-			assert!(p as isize > last_p);
-			last_p = p as isize;
-			values[p] = v;
-		}
+        // One last iteration to pick up all updates
+        let mut last_p = -1;
+        for (p, v) in transfer.iterate(true) {
+            assert!(p as isize > last_p);
+            last_p = p as isize;
+            values[p] = v;
+        }
 
-		// Now there should be no more updates
-		assert!(transfer.iterate(true).next().is_none());
+        // Now there should be no more updates
+        assert!(transfer.iterate(true).next().is_none());
 
-		// Verify final values
-		for p in 0..PARAMETERS {
-			assert!((0..THREADS).any(|t| results[t][p] == values[p]));
-		}
+        // Verify final values
+        for p in 0..PARAMETERS {
+            assert!((0..THREADS).any(|t| results[t][p] == values[p]));
+        }
     }
 }

--- a/src/util/parameter_transfer.rs
+++ b/src/util/parameter_transfer.rs
@@ -1,0 +1,106 @@
+use std::mem::size_of;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+const USIZE_BITS: usize = size_of::<usize>() * 8;
+
+fn word_and_bit(index: usize) -> (usize, usize) {
+	(index / USIZE_BITS, 1usize << (index & (USIZE_BITS - 1)))
+}
+
+/// A set of parameters that can be shared between threads.
+///
+/// Supports efficient iteration over parameters that changed since last iteration.
+#[derive(Default)]
+pub struct ParameterTransfer {
+	// TODO: Change values to AtomicU32 when stabilized (expected in 1.34).
+	values: Vec<AtomicUsize>,
+	changed: Vec<AtomicUsize>,
+}
+
+impl ParameterTransfer {
+	/// Create a new parameter set with `parameter_count` parameters.
+	pub fn new(parameter_count: usize) -> Self {
+		let bit_words = (parameter_count + USIZE_BITS - 1) / USIZE_BITS;
+		ParameterTransfer {
+			values: (0..parameter_count).map(|_| AtomicUsize::new(0)).collect(),
+			changed: (0..bit_words).map(|_| AtomicUsize::new(0)).collect(),
+		}
+	}
+
+	/// Set the value of the parameter with index `index` to `value` and mark
+	/// it as changed.
+	pub fn set_parameter(&self, index: usize, value: f32) {
+		let (word, bit) = word_and_bit(index);
+		self.values[index].store(value.to_bits() as usize, Ordering::Relaxed);
+		self.changed[word].fetch_or(bit, Ordering::AcqRel);
+	}
+
+	/// Get the current value of the parameter with index `index`.
+	pub fn get_parameter(&self, index: usize) -> f32 {
+		f32::from_bits(self.values[index].load(Ordering::Relaxed) as u32)
+	}
+
+	/// Iterate over all parameters marked as changed. If `acquire` is `true`,
+	/// mark all returned parameters as no longer changed.
+	///
+	/// The iterator returns a pair of `(index, value)` for each changed parameter.
+	///
+	/// The iterator is conservative is the sense that it is guaranteed to report
+	/// changed parameters, but if a parameter is changed multiple times in a short
+	/// period of time, it may skip some of the changes (but never the last) and
+	/// may report an extra, spurious change at the end.
+	///
+	/// The changed parameters are reported in increasing index order, and the same
+	/// parameter is never reported more than once in the same iteration.
+	pub fn iterate<'pt>(&'pt self, acquire: bool) -> ParameterTransferIterator<'pt> {
+		ParameterTransferIterator {
+			pt: self,
+			word: 0,
+			bit: 1,
+			acquire,
+		}
+	}
+}
+
+/// An iterator over changed parameters.
+/// Returned by [`iterate`](struct.ParameterTransfer.html#method.iterate).
+pub struct ParameterTransferIterator<'pt> {
+	pt: &'pt ParameterTransfer,
+	word: usize,
+	bit: usize,
+	acquire: bool,
+}
+
+impl<'pt> Iterator for ParameterTransferIterator<'pt> {
+	type Item = (usize, f32);
+
+	fn next(&mut self) -> Option<(usize, f32)> {
+		let bits = loop {
+			if self.word == self.pt.changed.len() {
+				return None
+			}
+			let bits = self.pt.changed[self.word].load(Ordering::Acquire) & self.bit.wrapping_neg();
+			if bits != 0 { break bits; }
+			self.word += 1;
+			self.bit = 1;
+		};
+
+		let bit_index = bits.trailing_zeros() as usize;
+		let bit = 1usize << bit_index;
+		let index = self.word * USIZE_BITS + bit_index;
+
+		if self.acquire {
+			self.pt.changed[self.word].fetch_and(!bit, Ordering::AcqRel);
+		}
+
+		let next_bit = bit << 1;
+		if next_bit == 0 {
+			self.word += 1;
+			self.bit = 1;
+		} else {
+			self.bit = next_bit;
+		}
+
+		Some((index, self.pt.get_parameter(index)))
+	}
+}


### PR DESCRIPTION
This is a couple of structs to make it easier to handle the communication between the UI and processing threads. In particular, they will help when porting VST plugins from the old to the new API after https://github.com/rust-dsp/rust-vst/pull/65 lands. The plan is to add an example (based on [transfer_and_smooth](https://github.com/askeksa/transfer_and_smooth)) containing a detailed guide on how to port an existing plugin using [`ParameterTransfer`](https://github.com/askeksa/rust-vst/blob/utility_module/src/util/parameter_transfer.rs).

Before merging this, I would like some feedback on these issues:

1. General proofreading of the documentation. Is it adequate?

2. The [`AtomicFloat`](https://github.com/askeksa/rust-vst/blob/utility_module/src/util/atomic_float.rs) struct is specialized to `Relaxed` ordering, because this is what is usually needed for VST parameters. For this reason, its accessors are called `get` and `set` instead of the usual `load` and `store` of atomics. An alternative could be to just have `load` and `store` operations that include an ordering parameter.

3. A review of the [`ParameterTransfer`](https://github.com/askeksa/rust-vst/blob/utility_module/src/util/parameter_transfer.rs) data structure, especially its use of atomics. I have convinced myself that it upholds its promises no matter what happens, but more eyes are always useful.

Both structs have been tested in real VST use with the exact same code as in this PR - `AtomicFloat` as part of the examples in https://github.com/rust-dsp/rust-vst/pull/65, and `ParameterTransfer` as part of [transfer_and_smooth](https://github.com/askeksa/transfer_and_smooth).