### PR TITLE
Use dyn syntax for trait objects.

### DIFF
--- a/examples/dimension_expander.rs
+++ b/examples/dimension_expander.rs
@@ -184,8 +184,8 @@ impl Plugin for DimensionExpander {
         }
     }
 
-    fn get_parameter_object(&mut self) -> Arc<PluginParameters> {
-        Arc::clone(&self.params) as Arc<PluginParameters>
+    fn get_parameter_object(&mut self) -> Arc<dyn PluginParameters> {
+        Arc::clone(&self.params) as Arc<dyn PluginParameters>
     }
 }
 

--- a/examples/gain_effect.rs
+++ b/examples/gain_effect.rs
@@ -86,8 +86,8 @@ impl Plugin for GainEffect {
 
     // Return the parameter object. This method can be omitted if the
     // plugin has no parameters.
-    fn get_parameter_object(&mut self) -> Arc<PluginParameters> {
-        Arc::clone(&self.params) as Arc<PluginParameters>
+    fn get_parameter_object(&mut self) -> Arc<dyn PluginParameters> {
+        Arc::clone(&self.params) as Arc<dyn PluginParameters>
     }
 }
 

--- a/examples/transfer_and_smooth.rs
+++ b/examples/transfer_and_smooth.rs
@@ -84,8 +84,8 @@ impl Plugin for MyPlugin {
     }
 
     // 5. Return a reference to the parameter struct from get_parameter_object.
-    fn get_parameter_object(&mut self) -> Arc<PluginParameters> {
-        Arc::clone(&self.params) as Arc<PluginParameters>
+    fn get_parameter_object(&mut self) -> Arc<dyn PluginParameters> {
+        Arc::clone(&self.params) as Arc<dyn PluginParameters>
     }
 
     fn set_sample_rate(&mut self, sample_rate: f32) {

--- a/src/api.rs
+++ b/src/api.rs
@@ -149,14 +149,14 @@ impl AEffect {
     // Supresses warning about returning a reference to a box
     #[allow(unknown_lints)]
     #[allow(clippy::borrowed_box)]
-    pub unsafe fn get_plugin(&mut self) -> &mut Box<Plugin> {
+    pub unsafe fn get_plugin(&mut self) -> &mut Box<dyn Plugin> {
         //FIXME: find a way to do this without resorting to transmuting via a box
-        &mut *(self.object as *mut Box<Plugin>)
+        &mut *(self.object as *mut Box<dyn Plugin>)
     }
 
     /// Drop the Plugin object. Only works for plugins created using this library.
     pub unsafe fn drop_plugin(&mut self) {
-        drop(Box::from_raw(self.object as *mut Box<Plugin>));
+        drop(Box::from_raw(self.object as *mut Box<dyn Plugin>));
         drop(Box::from_raw(self.user as *mut super::PluginCache));
     }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -389,14 +389,14 @@ impl SendEventBuffer {
     /// # }
     /// ```
     #[inline(always)]
-    pub fn send_events<T: IntoIterator<Item = U>, U: WriteIntoPlaceholder>(&mut self, events: T, host: &mut Host) {
+    pub fn send_events<T: IntoIterator<Item = U>, U: WriteIntoPlaceholder>(&mut self, events: T, host: &mut dyn Host) {
         self.store_events(events);
         host.process_events(self.events());
     }
 
     /// Sends events from the host to a plugin.
     #[inline(always)]
-    pub fn send_events_to_plugin<T: IntoIterator<Item = U>, U: WriteIntoPlaceholder>(&mut self, events: T, plugin: &mut Plugin) {
+    pub fn send_events_to_plugin<T: IntoIterator<Item = U>, U: WriteIntoPlaceholder>(&mut self, events: T, plugin: &mut dyn Plugin) {
         self.store_events(events);
         plugin.process_events(self.events());
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -5,15 +5,15 @@ use plugin::{Info, PluginParameters};
 
 pub(crate) struct PluginCache {
     pub info: Info,
-    pub params: Arc<PluginParameters>,
-    pub editor: Option<Box<Editor>>
+    pub params: Arc<dyn PluginParameters>,
+    pub editor: Option<Box<dyn Editor>>
 }
 
 impl PluginCache {
     pub fn new(
         info: &Info,
-        params: Arc<PluginParameters>,
-        editor: Option<Box<Editor>>
+        params: Arc<dyn PluginParameters>,
+        editor: Option<Box<dyn Editor>>
     ) -> Self {
         Self {
             info: info.clone(),

--- a/src/host.rs
+++ b/src/host.rs
@@ -625,8 +625,8 @@ impl Plugin for PluginInstance {
     }
 
 
-    fn get_parameter_object(&mut self) -> Arc<PluginParameters> {
-        Arc::clone(&self.params) as Arc<PluginParameters>
+    fn get_parameter_object(&mut self) -> Arc<dyn PluginParameters> {
+        Arc::clone(&self.params) as Arc<dyn PluginParameters>
     }
 }
 

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -315,7 +315,7 @@ pub fn dispatch(
 }
 
 pub fn host_dispatch(
-    host: &mut Host,
+    host: &mut dyn Host,
     effect: *mut AEffect,
     opcode: i32,
     index: i32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,7 +257,7 @@ pub fn main<T: Plugin + Default>(callback: HostCallbackProc) -> *mut AEffect {
             _offQualities: 0,
             _ioRatio: 0.0,
 
-            object: Box::into_raw(Box::new(Box::new(plugin) as Box<Plugin>)) as *mut _,
+            object: Box::into_raw(Box::new(Box::new(plugin) as Box<dyn Plugin>)) as *mut _,
             user: Box::into_raw(Box::new(PluginCache::new(&info, params, editor))) as *mut _,
 
             uniqueId: info.unique_id,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -656,7 +656,7 @@ pub trait Plugin {
     fn process_events(&mut self, events: &api::Events) {}
 
     /// Get a reference to the shared parameter object.
-    fn get_parameter_object(&mut self) -> Arc<PluginParameters> {
+    fn get_parameter_object(&mut self) -> Arc<dyn PluginParameters> {
         Arc::new(DummyPluginParameters)
     }
 
@@ -698,7 +698,7 @@ pub trait Plugin {
     ///
     /// The editor object will typically contain an `Arc` reference to the parameter
     /// object through which it can communicate with the audio processing.
-    fn get_editor(&mut self) -> Option<Box<Editor>> {
+    fn get_editor(&mut self) -> Option<Box<dyn Editor>> {
         None
     }
 }


### PR DESCRIPTION
For improved clarity in the code and examples, use the new `dyn` syntax for all trait objects.

This ups the minimum required Rust version for the crate to 1.27, which is 10 months old.