### PR TITLE
update osx bundler to account for macOS code signing

### DIFF
--- a/osx_vst_bundler.sh
+++ b/osx_vst_bundler.sh
@@ -54,8 +54,18 @@ else
 </dict>
 </plist>" > "$1.vst/Contents/Info.plist"
 
-    # move the provided library to the correct location
-    cp "$2" "$1.vst/Contents/MacOS/$1"
+    # Move the provided library to the correct location by removing the original
+    # file and copying the new one in place.
+    #
+    # We must remove the original file because modern macOS code signatures are
+    # cached by inode; copying over the file will not change the inode and the
+    # signature of the new dylib will no longer match the cached signature.
+    #
+    # See https://developer.apple.com/documentation/security/updating_mac_software
+
+    tgt="$1.vst/Contents/MacOS/$1"
+    rm -f "$1"
+    cp "$2" "$1"
 
     echo "Created bundle $1.vst"
 fi


### PR DESCRIPTION
Hi!

This caused me a fair amount of pain as I tried to work through a fun tutorial using this library. Hopefully this small change helps out.

If the script is run twice writing into the same directory, the inode is reused